### PR TITLE
add OpenBD::Responses::Coverage#size

### DIFF
--- a/lib/openbd/responses/coverage.rb
+++ b/lib/openbd/responses/coverage.rb
@@ -6,6 +6,10 @@ module OpenBD
       def each(&block)
         body.each(&block)
       end
+
+      def size
+        body.size
+      end
     end
   end
 end

--- a/spec/openbd/client_spec.rb
+++ b/spec/openbd/client_spec.rb
@@ -91,5 +91,10 @@ RSpec.describe OpenBD::Client do
       expect(res).to be_kind_of OpenBD::Responses::Coverage
       expect(res.body).to be == coverages
     end
+
+    it "has a method size()" do
+      res = client.coverage
+      expect(res.size).to be == 5
+    end
   end
 end


### PR DESCRIPTION
とりあえずOpenBDの全登録件数をとりたくなったので、OpenBD::Responses::Coverageにsizeメソッドを追加してみました。